### PR TITLE
Feat/#16 write test for failing case

### DIFF
--- a/src/input_circuit.rs
+++ b/src/input_circuit.rs
@@ -236,10 +236,18 @@ mod tests {
         // calculate the proof by passing witness variable value
         let proof = Groth16::<Bls12_377>::prove(&circuit_pk, circuit.clone(), &mut rng).unwrap();
 
-        // // validate the proof
+        // validate the proof
         assert!(Groth16::<Bls12_377>::verify(
             &circuit_vk,
             &[lower_bound, upper_bound, h_x.x, h_x.y],
+            &proof
+        )
+        .unwrap());
+
+        // expected to fail
+        assert!(!Groth16::<Bls12_377>::verify(
+            &circuit_vk,
+            &[lower_bound, upper_bound, h_x.y, h_x.x],
             &proof
         )
         .unwrap());

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -410,7 +410,7 @@ pub mod zkpopk {
                     parameters.sec as usize
                 ];
 
-            let witness = Witness::new(m, &x, &r);
+            let witness = Witness::new(m.clone(), &x, &r);
 
             let sk = SecretKey::generate(&she_params, &mut rng);
 
@@ -426,6 +426,20 @@ pub mod zkpopk {
             let proof = prove(&parameters, &witness, &instance, &she_params);
 
             verify(&proof, &parameters, &instance, &she_params).unwrap();
+
+            let invalid_x: Vec<Encodedtext> =
+                vec![Encodedtext::rand(&she_params, &mut rng); parameters.sec as usize];
+            let invalid_r: Vec<Encodedtext> =
+                vec![
+                    Encodedtext::from_vec(vec![Fq::zero(); parameters.d as usize]);
+                    parameters.sec as usize
+                ];
+
+            let invalid_witness = Witness::new(m, &invalid_x, &invalid_r);
+
+            let invalid_proof = prove(&parameters, &invalid_witness, &instance, &she_params);
+
+            verify(&invalid_proof, &parameters, &instance, &she_params).unwrap_err();
         }
     }
 }

--- a/src/she.rs
+++ b/src/she.rs
@@ -194,5 +194,15 @@ mod tests {
         let expected_pt = pt.clone() * pt_2.clone() + pt_3.clone();
 
         assert_eq!(expected_pt, dect);
+
+        // expected to fail
+        let dect = ct.decrypt(&secret_key).decode(&she_params);
+        assert!(!(pt_2 == dect));
+
+        // expected to fail
+        let expr_ct = ct.clone() + ct_2.clone();
+        let dect = expr_ct.decrypt(&secret_key).decode(&she_params);
+        let not_expected_pt = pt.clone() + pt_3.clone();
+        assert!(!(not_expected_pt == dect));
     }
 }


### PR DESCRIPTION
fix #16 

changes:
- add failing test code
  - she.rs
    - Add that in some cases encrypt then decryprt results are different
  - input_circuit.rs
    - Add a case that fails when invalid witness in Groth16
  - preprocessing.rs
    - Add a case that fails when invalid witness in ZKPoPK
- error handling
  - preprocessing.rs
    - Fix return value of "fn verify" in ZKPoPK that was not implemented correctly.