### PR TITLE
Feat/random bit generation

### DIFF
--- a/mpc-algebra/examples/test.rs
+++ b/mpc-algebra/examples/test.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
+use ark_ff::{One, Zero};
 use log::debug;
-use mpc_algebra::{AdditiveFieldShare, MpcField, Reveal};
+use mpc_algebra::{AdditiveFieldShare, MpcField, Reveal, UniformBitRand};
 use mpc_net::{MpcMultiNet as Net, MpcNet};
 
 use structopt::StructOpt;
@@ -68,6 +69,26 @@ fn test_sum() {
     assert_eq!(result.reveal(), F::from(6u64));
 }
 
+fn test_bit_rand() {
+    let mut rng = ark_std::test_rng();
+    let mut counter = [0, 0, 0];
+
+    for i in 0..1000 {
+        let a = MF::bit_rand(&mut rng).reveal();
+
+        if a.is_zero() {
+            counter[0] += 1;
+        } else if a.is_one() {
+            counter[1] += 1;
+        } else {
+            counter[2] += 1;
+        }
+    }
+
+    assert_eq!(counter[2], 0); // should be 0 (no other value than 0 or 1 is allowed in the current implementation
+    println!("{:?}", counter);
+}
+
 fn main() {
     env_logger::builder().format_timestamp(None).init();
     debug!("Start");
@@ -80,4 +101,6 @@ fn main() {
     test_mul();
     test_div();
     test_sum();
+
+    test_bit_rand();
 }

--- a/mpc-algebra/src/lib.rs
+++ b/mpc-algebra/src/lib.rs
@@ -6,6 +6,8 @@ pub mod share;
 pub use share::*;
 pub mod wire;
 pub use wire::*;
+pub mod mpc_primitives;
+pub use mpc_primitives::*;
 
 pub mod channel;
 

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -1,0 +1,5 @@
+use rand::Rng;
+
+pub trait UniformBitRand: Sized {
+    fn bit_rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
+}


### PR DESCRIPTION
Implemented random bit share generation.

This method is based on the following paper: [Nishide, Takashi, and Kazuo Ohta. 2007. “Multiparty Computation for Interval, Equality, and Comparison without Bit-Decomposition Protocol.” In Public Key Cryptography – PKC 2007, 343–60. Berlin, Heidelberg: Springer Berlin Heidelberg.](https://www.iacr.org/archive/pkc2007/44500343/44500343.pdf)