### PR TITLE
Feat/mpc primitives

### DIFF
--- a/mpc-algebra/examples/test.rs
+++ b/mpc-algebra/examples/test.rs
@@ -1,8 +1,11 @@
 use std::path::PathBuf;
 
 use ark_ff::{One, Zero};
+use ark_poly::reveal;
 use log::debug;
-use mpc_algebra::{AdditiveFieldShare, MpcField, Reveal, UniformBitRand};
+use mpc_algebra::{
+    AdditiveFieldShare, EqualityZero, LogicalOperations, MpcField, Reveal, UniformBitRand,
+};
 use mpc_net::{MpcMultiNet as Net, MpcNet};
 
 use structopt::StructOpt;
@@ -73,7 +76,7 @@ fn test_bit_rand() {
     let mut rng = ark_std::test_rng();
     let mut counter = [0, 0, 0];
 
-    for i in 0..1000 {
+    for _ in 0..1000 {
         let a = MF::bit_rand(&mut rng).reveal();
 
         if a.is_zero() {
@@ -86,6 +89,110 @@ fn test_bit_rand() {
     }
 
     assert_eq!(counter[2], 0); // should be 0 (no other value than 0 or 1 is allowed in the current implementation
+    println!("{:?}", counter);
+}
+
+fn test_bits_rand() {
+    let mut rng = ark_std::test_rng();
+
+    let (a, b) = MF::bits_rand(&mut rng);
+
+    let revealed_a = a.iter().map(|x| x.reveal()).collect::<Vec<_>>();
+    let revealed_b = b.reveal();
+
+    // bits representation is given in big-endian
+    let sum = revealed_a
+        .iter()
+        .fold(F::zero(), |acc, x| acc * F::from(2) + x);
+
+    assert_eq!(sum, revealed_b);
+}
+
+fn test_and() {
+    let mut rng = ark_std::test_rng();
+
+    let a00 = vec![MF::zero(), MF::zero()];
+    let a10 = vec![MF::one(), MF::zero()];
+    let a11 = vec![MF::one(), MF::one()];
+
+    assert_eq!(a00.unbounded_fan_in_and().reveal(), F::zero());
+    assert_eq!(a10.unbounded_fan_in_and().reveal(), F::zero());
+    assert_eq!(a11.unbounded_fan_in_and().reveal(), F::one());
+
+    let mut counter = [0, 0];
+
+    for _ in 0..100 {
+        let a = (0..3).map(|_| MF::bit_rand(&mut rng)).collect::<Vec<_>>();
+
+        let res = a.unbounded_fan_in_and();
+
+        println!("unbounded and is {:?}", res.reveal());
+        if res.reveal().is_zero() {
+            counter[0] += 1;
+        } else if res.reveal().is_one() {
+            counter[1] += 1;
+        }
+    }
+    println!("AND counter is {:?}", counter);
+}
+
+fn test_or() {
+    let mut rng = ark_std::test_rng();
+
+    let a00 = vec![MF::zero(), MF::zero()];
+    let a10 = vec![MF::one(), MF::zero()];
+    let a11 = vec![MF::one(), MF::one()];
+
+    assert_eq!(a00.unbounded_fan_in_or().reveal(), F::zero());
+    assert_eq!(a10.unbounded_fan_in_or().reveal(), F::one());
+    assert_eq!(a11.unbounded_fan_in_or().reveal(), F::one());
+
+    let mut counter = [0, 0];
+
+    for _ in 0..100 {
+        let a = (0..3).map(|_| MF::bit_rand(&mut rng)).collect::<Vec<_>>();
+
+        let res = a.unbounded_fan_in_or();
+
+        println!("unbounded or is {:?}", res.reveal());
+        if res.reveal().is_zero() {
+            counter[0] += 1;
+        } else if res.reveal().is_one() {
+            counter[1] += 1;
+        }
+    }
+    println!("OR counter is {:?}", counter);
+}
+
+fn test_equality_zero() {
+    let mut rng = ark_std::test_rng();
+
+    let mut counter = [0, 0];
+
+    // a is zero
+    let a = MF::from_add_shared(F::zero());
+    let res = a.is_zero_shared();
+    assert!(res.reveal().is_one());
+
+    // a is not zero
+    let a = MF::from_add_shared(F::one());
+    let res = a.is_zero_shared();
+    assert!(res.reveal().is_zero());
+
+    // a is random bit
+    for _ in 0..10 {
+        let a = MF::bit_rand(&mut rng);
+
+        let res = a.is_zero_shared();
+
+        println!("is_zero is {:?}", res.reveal());
+
+        if res.reveal().is_zero() {
+            counter[0] += 1;
+        } else if res.reveal().is_one() {
+            counter[1] += 1;
+        }
+    }
     println!("{:?}", counter);
 }
 
@@ -103,4 +210,8 @@ fn main() {
     test_sum();
 
     test_bit_rand();
+    test_bits_rand();
+    test_and();
+    test_or();
+    test_equality_zero();
 }

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -14,3 +14,7 @@ pub trait LogicalOperations {
 
     fn unbounded_fan_in_or(&self) -> Self::Output;
 }
+
+pub trait EqualityZero {
+    fn is_zero_shared(&self) -> Self;
+}

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -6,3 +6,11 @@ pub trait UniformBitRand: Sized {
     // big-endian
     fn bits_rand<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self);
 }
+
+pub trait LogicalOperations {
+    type Output;
+
+    fn unbounded_fan_in_and(&self) -> Self::Output;
+
+    fn unbounded_fan_in_or(&self) -> Self::Output;
+}

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -3,8 +3,8 @@ use rand::Rng;
 pub trait UniformBitRand: Sized {
     fn bit_rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
 
-    // big-endian
-    fn bits_rand<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self);
+    // little-endian
+    fn rand_number_bitwise<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self);
 }
 
 pub trait BitwiseLessThan {

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -2,4 +2,7 @@ use rand::Rng;
 
 pub trait UniformBitRand: Sized {
     fn bit_rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
+
+    // big-endian
+    fn bits_rand<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self);
 }

--- a/mpc-algebra/src/mpc_primitives.rs
+++ b/mpc-algebra/src/mpc_primitives.rs
@@ -7,6 +7,12 @@ pub trait UniformBitRand: Sized {
     fn bits_rand<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self);
 }
 
+pub trait BitwiseLessThan {
+    type Output;
+
+    fn bitwise_lt(&self, other: &Self) -> Self::Output;
+}
+
 pub trait LogicalOperations {
     type Output;
 


### PR DESCRIPTION
Implement the following:
- random number bitwise generation (Need validation that is less then p)
- unbounded fan-in AND/OR
- Equality zero test (EQZ)

These methods are based on the following paper: [Nishide, Takashi, and Kazuo Ohta. 2007. “Multiparty Computation for Interval, Equality, and Comparison without Bit-Decomposition Protocol.” In Public Key Cryptography – PKC 2007, 343–60. Berlin, Heidelberg: Springer Berlin Heidelberg.](https://www.iacr.org/archive/pkc2007/44500343/44500343.pdf)