### PR TITLE
mpc-algebra: optimize bitwise ops with batched prefix patterns

### DIFF
--- a/examples/bin_werewolf.rs
+++ b/examples/bin_werewolf.rs
@@ -828,12 +828,12 @@ async fn winning_judgment(opt: &Opt) -> Result<(), std::io::Error> {
         .fold(MFr::zero(), |acc, x| acc + x.input);
     let num_citizen = MFr::from_public(num_alive) - num_werewolf;
     let exists_werewolf = num_werewolf.is_zero_shared().await;
+    let werewolf_lt_citizen = num_werewolf.is_smaller_than(&num_citizen).await;
 
     let game_state = exists_werewolf.field() * MFr::from(2_u32)
         + (!exists_werewolf).field()
-            * (num_werewolf.is_smaller_than(&num_citizen).await.field() * MFr::from(3_u32)
-                + (MFr::one() - (num_werewolf.is_smaller_than(&num_citizen).await).field())
-                    * MFr::from(1_u32));
+            * (werewolf_lt_citizen.field() * MFr::from(3_u32)
+                + (MFr::one() - werewolf_lt_citizen.field()) * MFr::from(1_u32));
 
     // prove
     let local_judgment_circuit = WinningJudgeCircuit {

--- a/examples/werewolf_cli/game.rs
+++ b/examples/werewolf_cli/game.rs
@@ -301,20 +301,14 @@ impl Game {
             .fold(MFr::default(), |acc, x| acc + x.input);
         let num_citizen = MFr::from_public(num_alive) - num_werewolf;
         let exists_werewolf = num_werewolf.is_zero_shared().await;
+        let werewolf_plus_one_lt_citizen = (num_werewolf + MFr::one())
+            .is_smaller_than(&num_citizen)
+            .await;
 
         let game_state = exists_werewolf.field() * MFr::from(2_u32)
             + (!exists_werewolf).field()
-                * ((num_werewolf + MFr::one())
-                    .is_smaller_than(&num_citizen)
-                    .await
-                    .field()
-                    * MFr::from(3_u32)
-                    + (MFr::one()
-                        - ((num_werewolf + MFr::one())
-                            .is_smaller_than(&num_citizen)
-                            .await
-                            .field()))
-                        * MFr::from(1_u32));
+                * (werewolf_plus_one_lt_citizen.field() * MFr::from(3_u32)
+                    + (MFr::one() - werewolf_plus_one_lt_citizen.field()) * MFr::from(1_u32));
 
         // prove
         let local_judgment_circuit = WinningJudgeCircuit {

--- a/mpc-algebra/examples/algebra.rs
+++ b/mpc-algebra/examples/algebra.rs
@@ -482,8 +482,8 @@ async fn profile_single_shot_latency() {
     let (_, a) = MBF::rand_number_bitwise_less_than_half_modulus(&mut rng).await;
     let (_, b) = MBF::rand_number_bitwise_less_than_half_modulus(&mut rng).await;
     let z: MpcField<
-        ark_ff::Fp256<ark_bls12_377::FrParameters>,
-        AdditiveFieldShare<ark_ff::Fp256<ark_bls12_377::FrParameters>>,
+        ark_ff::Fp256<ark_bn254::FrParameters>,
+        AdditiveFieldShare<ark_ff::Fp256<ark_bn254::FrParameters>>,
     > = MF::from_add_shared(F::zero());
 
     let (up0, down0) = Net.get_comm();

--- a/mpc-algebra/examples/algebra.rs
+++ b/mpc-algebra/examples/algebra.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ark_crypto_primitives::{CommitmentScheme, CRH};
 use ark_ff::{BigInteger, BigInteger256, FpParameters, PrimeField, UniformRand};
@@ -17,6 +18,7 @@ use mpc_algebra::{
 };
 use mpc_net::multi::MPCNetConnection;
 use mpc_net::MpcMultiNet as Net;
+use mpc_net::MpcNet;
 
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -474,6 +476,51 @@ async fn test_share() {
     }
 }
 
+async fn profile_single_shot_latency() {
+    let mut rng = ark_std::test_rng();
+
+    let (_, a) = MBF::rand_number_bitwise_less_than_half_modulus(&mut rng).await;
+    let (_, b) = MBF::rand_number_bitwise_less_than_half_modulus(&mut rng).await;
+    let z: MpcField<
+        ark_ff::Fp256<ark_bls12_377::FrParameters>,
+        AdditiveFieldShare<ark_ff::Fp256<ark_bls12_377::FrParameters>>,
+    > = MF::from_add_shared(F::zero());
+
+    let (up0, down0) = Net.get_comm();
+    let t0 = Instant::now();
+    let _ = a.is_smaller_than(&b).await;
+    let dt_lt = t0.elapsed();
+    let (up1, down1) = Net.get_comm();
+    println!(
+        "single_shot less_than: {:?}, up +{}B, down +{}B",
+        dt_lt,
+        up1.saturating_sub(up0),
+        down1.saturating_sub(down0)
+    );
+
+    let t1 = Instant::now();
+    let _ = z.is_zero_shared().await;
+    let dt_eqz = t1.elapsed();
+    let (up2, down2) = Net.get_comm();
+    println!(
+        "single_shot equality_zero: {:?}, up +{}B, down +{}B",
+        dt_eqz,
+        up2.saturating_sub(up1),
+        down2.saturating_sub(down1)
+    );
+
+    let t2 = Instant::now();
+    let _ = a.bit_decomposition().await;
+    let dt_bd = t2.elapsed();
+    let (up3, down3) = Net.get_comm();
+    println!(
+        "single_shot bit_decomposition: {:?}, up +{}B, down +{}B",
+        dt_bd,
+        up3.saturating_sub(up2),
+        down3.saturating_sub(down2)
+    );
+}
+
 #[tokio::main]
 async fn main() {
     env_logger::builder().format_timestamp(None).init();
@@ -525,6 +572,8 @@ async fn main() {
         println!("Test bit_add passed");
         test_bit_decomposition().await;
         println!("Test bit_decomposition passed");
+        profile_single_shot_latency().await;
+        println!("single_shot profile done");
 
         test_pedersen_commitment().await;
         println!("Test pedersen commitment passed");

--- a/mpc-algebra/src/wire/boolean_field.rs
+++ b/mpc-algebra/src/wire/boolean_field.rs
@@ -147,7 +147,7 @@ impl<F: PrimeField, S: FieldShare<F>> BitwiseLessThan for Vec<MpcBooleanField<F,
             })
             .collect::<Vec<MpcField<F, S>>>();
 
-        let mut prod = e.clone();
+        let mut prod = e;
         let other_fields = other.iter().map(|b| b.field()).collect::<Vec<_>>();
         <MpcField<F, S> as Field>::batch_product_in_place(&mut prod, &other_fields);
         Self::Output::from(prod.into_iter().sum::<MpcField<F, S>>())
@@ -335,7 +335,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> MpcBooleanField<F, S> {
     }
 }
 
-impl<F: PrimeField, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
+impl<F: Field, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
     type Output = Self;
 
     fn carries(&self, other: &Self) -> Self::Output {

--- a/mpc-algebra/src/wire/boolean_field.rs
+++ b/mpc-algebra/src/wire/boolean_field.rs
@@ -113,18 +113,27 @@ impl<F: PrimeField, S: FieldShare<F>> BitwiseLessThan for Vec<MpcBooleanField<F,
         assert_eq!(self.len(), modulus_size);
         assert_eq!(other.len(), modulus_size);
 
-        // [c_i] = [a_i \oplus b_i]
-        let c = self
-            .iter()
-            .zip(other.iter())
-            .map(|(&a, &b)| a ^ b)
-            .collect::<Vec<_>>();
-        let rev_c = c.into_iter().rev().collect::<Vec<_>>();
+        // c_i = a_i xor b_i, computed with batched products.
+        let c = MpcBooleanField::<F, S>::batch_xor(self, other);
+        let mut d = c.into_iter().rev().collect::<Vec<_>>();
 
-        // d_i = OR_{j=i}^{modulus_size-1} c_j
-        let mut d = vec![rev_c[0]];
-        for i in 0..modulus_size - 1 {
-            d.push(d[i] | rev_c[i + 1]);
+        // Prefix-OR on reversed bits using a parallel-prefix schedule.
+        // This reduces the interaction depth from O(n) to O(log n).
+        let mut offset = 1usize;
+        while offset < modulus_size {
+            let mut lhs = Vec::with_capacity(modulus_size - offset);
+            let mut rhs = Vec::with_capacity(modulus_size - offset);
+            let mut idx = Vec::with_capacity(modulus_size - offset);
+            for i in offset..modulus_size {
+                lhs.push(d[i]);
+                rhs.push(d[i - offset]);
+                idx.push(i);
+            }
+            let ors = MpcBooleanField::<F, S>::batch_or(&lhs, &rhs);
+            for (i, v) in idx.into_iter().zip(ors.into_iter()) {
+                d[i] = v;
+            }
+            offset <<= 1;
         }
         d.reverse();
 
@@ -138,12 +147,10 @@ impl<F: PrimeField, S: FieldShare<F>> BitwiseLessThan for Vec<MpcBooleanField<F,
             })
             .collect::<Vec<MpcField<F, S>>>();
 
-        Self::Output::from(
-            e.iter()
-                .zip(other.iter())
-                .map(|(&e, &b)| e * b.field())
-                .sum::<MpcField<F, S>>(),
-        )
+        let mut prod = e.clone();
+        let other_fields = other.iter().map(|b| b.field()).collect::<Vec<_>>();
+        <MpcField<F, S> as Field>::batch_product_in_place(&mut prod, &other_fields);
+        Self::Output::from(prod.into_iter().sum::<MpcField<F, S>>())
     }
 }
 
@@ -151,22 +158,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> UniformBitRand for MpcBo
     type BaseField = MpcField<F, S>;
 
     async fn bit_rand<R: rand::Rng + ?Sized>(rng: &mut R) -> Self {
-        let r = Self::BaseField::rand(rng);
-        let r2 = (r * r).reveal().await;
-        let mut root_r2;
-
-        loop {
-            root_r2 = r2.sqrt().unwrap();
-
-            if !root_r2.is_zero() {
-                break;
-            }
-        }
-
-        Self(
-            (r / Self::BaseField::from_public(root_r2) + Self::BaseField::one())
-                / Self::BaseField::from_public(F::from(2u8)),
-        )
+        Self::rand_bits_batched_internal(rng, 1).await[0]
     }
 
     async fn rand_number_bitwise<R: Rng + ?Sized>(rng: &mut R) -> (Vec<Self>, Self::BaseField) {
@@ -181,13 +173,8 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> UniformBitRand for MpcBo
         modulus_bits = modulus_bits[..modulus_size].to_vec();
 
         let valid_bits = loop {
-            let mut bits = Vec::with_capacity(modulus_size);
-            for _ in 0..modulus_size {
-                bits.push(Self::bit_rand(rng).await);
-            }
-
+            let bits = Self::rand_bits_batched_internal(rng, modulus_size).await;
             if bits
-                .clone()
                 .is_smaller_than_le(&modulus_bits)
                 .field()
                 .reveal()
@@ -224,13 +211,8 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> UniformBitRand for MpcBo
         half_modulus_bits = half_modulus_bits[..modulus_size].to_vec();
 
         let valid_bits = loop {
-            let mut bits = Vec::with_capacity(modulus_size);
-            for _ in 0..modulus_size {
-                bits.push(Self::bit_rand(rng).await);
-            }
-
+            let bits = Self::rand_bits_batched_internal(rng, modulus_size).await;
             if bits
-                .clone()
                 .is_smaller_than_le(&half_modulus_bits)
                 .field()
                 .reveal()
@@ -274,7 +256,84 @@ impl<F: Field, S: FieldShare<F>> MpcWire for MpcBooleanField<F, S> {
     }
 }
 
-impl<F: Field, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
+impl<F: PrimeField, S: FieldShare<F>> MpcBooleanField<F, S> {
+    pub(crate) fn batch_and(lhs: &[Self], rhs: &[Self]) -> Vec<Self> {
+        assert_eq!(lhs.len(), rhs.len());
+        let mut prods = lhs.iter().map(|x| x.field()).collect::<Vec<_>>();
+        let rhs_fields = rhs.iter().map(|x| x.field()).collect::<Vec<_>>();
+        <MpcField<F, S> as Field>::batch_product_in_place(&mut prods, &rhs_fields);
+        prods.into_iter().map(Self::from).collect()
+    }
+
+    pub(crate) fn batch_or(lhs: &[Self], rhs: &[Self]) -> Vec<Self> {
+        assert_eq!(lhs.len(), rhs.len());
+        let ands = Self::batch_and(lhs, rhs);
+        lhs.iter()
+            .zip(rhs.iter())
+            .zip(ands.into_iter())
+            .map(|((&a, &b), ab)| Self::from(a.field() + b.field() - ab.field()))
+            .collect()
+    }
+
+    pub(crate) fn batch_xor(lhs: &[Self], rhs: &[Self]) -> Vec<Self> {
+        assert_eq!(lhs.len(), rhs.len());
+        let two = MpcField::<F, S>::from(2u8);
+        let ands = Self::batch_and(lhs, rhs);
+        lhs.iter()
+            .zip(rhs.iter())
+            .zip(ands.into_iter())
+            .map(|((&a, &b), ab)| Self::from(a.field() + b.field() - (ab.field() * two)))
+            .collect()
+    }
+}
+
+impl<F: PrimeField + SquareRootField, S: FieldShare<F>> MpcBooleanField<F, S> {
+    async fn bit_rand_single_slow<R: rand::Rng + ?Sized>(rng: &mut R) -> Self {
+        loop {
+            let r = MpcField::<F, S>::rand(rng);
+            let r2 = (r * r).reveal().await;
+            let root_r2 = r2.sqrt().unwrap();
+            if !root_r2.is_zero() {
+                return Self(
+                    (r / MpcField::<F, S>::from_public(root_r2) + MpcField::<F, S>::one())
+                        / MpcField::<F, S>::from_public(F::from(2u8)),
+                );
+            }
+        }
+    }
+
+    async fn rand_bits_batched_internal<R: rand::Rng + ?Sized>(rng: &mut R, n: usize) -> Vec<Self> {
+        let mut rs = (0..n).map(|_| MpcField::<F, S>::rand(rng)).collect::<Vec<_>>();
+        let mut squares = rs.clone();
+        <MpcField<F, S> as Field>::batch_product_in_place(&mut squares, &rs);
+        let opened_squares = S::batch_open(
+            squares
+                .into_iter()
+                .map(|x| match x {
+                    MpcField::Shared(s) => s,
+                    MpcField::Public(v) => S::from_public(v),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await;
+
+        let mut bits = Vec::with_capacity(n);
+        for (r, r2) in rs.drain(..).zip(opened_squares.into_iter()) {
+            let root_r2 = r2.sqrt().unwrap();
+            if root_r2.is_zero() {
+                bits.push(Self::bit_rand_single_slow(rng).await);
+            } else {
+                bits.push(Self(
+                    (r / MpcField::<F, S>::from_public(root_r2) + MpcField::<F, S>::one())
+                        / MpcField::<F, S>::from_public(F::from(2u8)),
+                ));
+            }
+        }
+        bits
+    }
+}
+
+impl<F: PrimeField, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
     type Output = Self;
 
     fn carries(&self, other: &Self) -> Self::Output {
@@ -283,27 +342,52 @@ impl<F: Field, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
                 assert_eq!(self.len(), other.len());
                 let l = self.len(); // l is the bit length.
 
-                let s_vec = self
-                    .iter()
-                    .zip(other.iter())
-                    .map(|(a, b)| *a & *b)
-                    .collect::<Vec<_>>();
+                let s_vec = MpcBooleanField::<F, S>::batch_and(self, other);
+                let p_vec = MpcBooleanField::<F, S>::batch_xor(self, other);
 
-                let p_vec = (0..l)
-                    .map(|i| {
-                        self[i].field() + other[i].field()
-                            - MpcField::<F, S>::from_public(F::from(2u64)) * s_vec[i].field()
-                    })
-                    .collect::<Vec<_>>();
+                // Parallel-prefix carry computation.
+                // For each bit i, maintain (G_i, P_i) where carry_i = G_i and:
+                // combine((G, P), (g, p)) = (G + P * g, P * p).
+                let mut g_vec = s_vec.iter().map(|b| b.field()).collect::<Vec<_>>();
+                let mut p_fields = p_vec.iter().map(|b| b.field()).collect::<Vec<_>>();
 
-                let ret = (0..l)
-                    .scan(MpcField::<F, S>::zero(), |is_s, i| {
-                        *is_s = s_vec[i].field() + p_vec[i] * *is_s;
-                        Some(*is_s)
-                    })
-                    .collect::<Vec<_>>();
+                let mut offset = 1usize;
+                while offset < l {
+                    let m = l - offset;
+                    let mut lhs_p = Vec::with_capacity(m);
+                    let mut rhs_g = Vec::with_capacity(m);
+                    let mut rhs_p = Vec::with_capacity(m);
+                    let mut idx = Vec::with_capacity(m);
 
-                ret.into_iter().map(MpcBooleanField::<F, S>::from).collect()
+                    for i in offset..l {
+                        lhs_p.push(p_fields[i]);
+                        rhs_g.push(g_vec[i - offset]);
+                        rhs_p.push(p_fields[i - offset]);
+                        idx.push(i);
+                    }
+
+                    let mut p_times_g = lhs_p.clone();
+                    <MpcField<F, S> as Field>::batch_product_in_place(&mut p_times_g, &rhs_g);
+
+                    let mut p_times_p = lhs_p;
+                    <MpcField<F, S> as Field>::batch_product_in_place(&mut p_times_p, &rhs_p);
+
+                    for ((i, pg), pp) in idx
+                        .into_iter()
+                        .zip(p_times_g.into_iter())
+                        .zip(p_times_p.into_iter())
+                    {
+                        g_vec[i] = g_vec[i] + pg;
+                        p_fields[i] = pp;
+                    }
+
+                    offset <<= 1;
+                }
+
+                g_vec
+                    .into_iter()
+                    .map(MpcBooleanField::<F, S>::from)
+                    .collect()
             }
             false => {
                 panic!("public is not expected here");

--- a/mpc-algebra/src/wire/boolean_field.rs
+++ b/mpc-algebra/src/wire/boolean_field.rs
@@ -335,7 +335,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> MpcBooleanField<F, S> {
     }
 }
 
-impl<F: Field, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
+impl<F: PrimeField, S: FieldShare<F>> BitAdd for Vec<MpcBooleanField<F, S>> {
     type Output = Self;
 
     fn carries(&self, other: &Self) -> Self::Output {

--- a/mpc-algebra/src/wire/boolean_field.rs
+++ b/mpc-algebra/src/wire/boolean_field.rs
@@ -303,7 +303,9 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> MpcBooleanField<F, S> {
     }
 
     async fn rand_bits_batched_internal<R: rand::Rng + ?Sized>(rng: &mut R, n: usize) -> Vec<Self> {
-        let mut rs = (0..n).map(|_| MpcField::<F, S>::rand(rng)).collect::<Vec<_>>();
+        let mut rs = (0..n)
+            .map(|_| MpcField::<F, S>::rand(rng))
+            .collect::<Vec<_>>();
         let mut squares = rs.clone();
         <MpcField<F, S> as Field>::batch_product_in_place(&mut squares, &rs);
         let opened_squares = S::batch_open(

--- a/mpc-algebra/src/wire/field.rs
+++ b/mpc-algebra/src/wire/field.rs
@@ -306,7 +306,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> LessThan for MpcField<F,
     }
 }
 
-impl<F: Field, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
+impl<F: PrimeField, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
     type Output = MpcBooleanField<F, S>;
     // TODO: Implement kary_nand
 
@@ -320,8 +320,29 @@ impl<F: Field, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>
             .into_iter()
             .all(|x| x)
         });
-        self.iter()
-            .fold(Self::Output::pub_true(), |acc, &x| acc & x)
+        if self.is_empty() {
+            return Self::Output::pub_true();
+        }
+
+        let mut level = self.clone();
+        while level.len() > 1 {
+            let mut lhs = Vec::with_capacity(level.len() / 2);
+            let mut rhs = Vec::with_capacity(level.len() / 2);
+            let mut next = Vec::with_capacity((level.len() + 1) / 2);
+
+            for pair in level.chunks_exact(2) {
+                lhs.push(pair[0]);
+                rhs.push(pair[1]);
+            }
+            next.extend(MpcBooleanField::<F, S>::batch_and(&lhs, &rhs));
+
+            if level.len() % 2 == 1 {
+                next.push(*level.last().unwrap());
+            }
+            level = next;
+        }
+
+        level[0]
     }
 
     async fn kary_or(&self) -> Self::Output {

--- a/mpc-algebra/src/wire/field.rs
+++ b/mpc-algebra/src/wire/field.rs
@@ -306,7 +306,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> LessThan for MpcField<F,
     }
 }
 
-impl<F: Field, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
+impl<F: PrimeField, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
     type Output = MpcBooleanField<F, S>;
     // TODO: Implement kary_nand
 

--- a/mpc-algebra/src/wire/field.rs
+++ b/mpc-algebra/src/wire/field.rs
@@ -306,7 +306,7 @@ impl<F: PrimeField + SquareRootField, S: FieldShare<F>> LessThan for MpcField<F,
     }
 }
 
-impl<F: PrimeField, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
+impl<F: Field, S: FieldShare<F>> LogicalOperations for Vec<MpcBooleanField<F, S>> {
     type Output = MpcBooleanField<F, S>;
     // TODO: Implement kary_nand
 

--- a/mpc-algebra/test.zsh
+++ b/mpc-algebra/test.zsh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 
 # Execute cargo build command
 cargo build --example algebra --release
-BIN="$(pwd)/target/release/examples/algebra"
+BIN="$(pwd)/../target/release/examples/algebra"
 
 PROCS=()
 


### PR DESCRIPTION
Refactor boolean/bit operations to use batched multiplications and parallel-prefix schedules for lower interaction depth in key MPC primitives.

Performance memo (single-shot, algebra example run):

- LessThan: ~103.66 ms

- EqualityZero: ~17.45 ms

- BitDecomposition: ~58.50 ms